### PR TITLE
add nix-based GitHub Actions workflow for building the iso

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -1,0 +1,13 @@
+name: "nix-build"
+on:
+  pull_request:
+  push:
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: cachix/install-nix-action@v10
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - run: nix-build

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ $(KERNEL_ELF): $(KERNEL_OBJS)
 iso: $(KERNEL_ELF)
 	cp kernel/$(KERNEL_SYMS) fsroot/boot
 	cp kernel/$(KERNEL_ELF)  fsroot/boot
-	scripts/gen-grubcfg $(KERNEL_ELF) $(KERNEL_VERSION) fsroot/boot/grub/grub.cfg
+	sh scripts/gen-grubcfg $(KERNEL_ELF) $(KERNEL_VERSION) fsroot/boot/grub/grub.cfg
 	grub-mkrescue -o potatOS.iso fsroot/
 
 # Clean build files

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # potatOS
+[![Actions Status](https://github.com/cometodukey/potatOS/workflows/nix-build/badge.svg?branch=develop)](https://github.com/cometodukey/potatOS/actions)
 
 potatOS is a small operating system for i686.
 

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,33 @@
+with import <nixpkgs> { };
+
+stdenv.mkDerivation {
+  name = "potatOS";
+  src = ./.;
+
+  buildInputs = with pkgs; [
+    # libraries
+    gmp
+    mpfr
+    libmpc
+    isl
+    zstd
+
+    # build phase
+    clang_10
+    lld
+    nasm
+
+    # iso building
+    grub2
+    xorriso
+  ];
+
+  buildPhase = ''
+    make CC=clang LD=ld.lld iso
+  '';
+
+  installPhase = ''
+    mkdir -p $out/iso/
+    mv potatOS.iso $out/iso/
+  '';
+}

--- a/shell.nix
+++ b/shell.nix
@@ -3,12 +3,14 @@ in pkgs.mkShell {
   buildInputs = with pkgs; [
 
     # build tools
+    lld
     gnumake
     qemu
     nasm
     grub2
     xorriso
     gdb
+    clang_10
 
     # libraries
     gmp
@@ -17,5 +19,5 @@ in pkgs.mkShell {
     isl
     zstd
 
-    ];
+  ];
 }


### PR DESCRIPTION
This PR adds three things:
- `default.nix` which builds the iso from start to finish
- `.git/workflows/nix-build.yml`, which is responsible for calling said `default.nix`
- A shiny new badge to the readme to show how cool it is!